### PR TITLE
[FEATURE] Configure whether or not to strip the prefix from constant names

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,21 @@ By default environment variables are passed as is to the constants file.
 But it is possible to specify a prefix for the constants.
 In the above example `environment.page.root` is written for env var `PAGE__ROOT`
 
+You can also strip the prefix from the constant names.
+To do so, the prefix needs to be the key, having a boolean value controlling whether or
+not to strip the prefix. 
+```
+	"files": {
+		"path/to/environment.t3s": [
+			"PAGE__",
+			"TYPOSCRIPT__" => true,
+			"TSCONFIG_" => false
+		]
+	}
+```
+Given the environment variable `TYPOSCRIPT__CONFIG__DEBUG = 1` would compile to `environment.config.debug = 1` 
+including the other constants as expected.
+
 *The default value* is `environment`
 
 #### `array-delimiter` [string]

--- a/src/TypoScriptConstantsFiles.php
+++ b/src/TypoScriptConstantsFiles.php
@@ -80,8 +80,13 @@ class TypoScriptConstantsFiles
     private function generateContentFromPrefixes(array $prefixes)
     {
         $content = '';
-        foreach ($prefixes as $prefix) {
-            $content .= $this->generateContentFromPrefix($prefix) . chr(10);
+        foreach ($prefixes as $prefix => $prefixOpts) {
+            if (is_numeric($prefix)) {
+                $content .= $this->generateContentFromPrefix($prefixOpts, false);
+            } else {
+                $content .= $this->generateContentFromPrefix($prefix, $prefixOpts);
+            }
+            $content .= chr(10);
         }
         $content = trim($content);
         return $content ? $content . chr(10) : '';
@@ -89,16 +94,17 @@ class TypoScriptConstantsFiles
 
     /**
      * @param string $prefix
+     * @param boolean $stripPrefix
      * @return string
      */
-    private function generateContentFromPrefix($prefix)
+    private function generateContentFromPrefix($prefix, $stripPrefix = false)
     {
         $content = '';
         foreach ($_ENV as $varName => $value) {
             if (strpos($varName, $prefix) === 0) {
                 $content .= sprintf(
                     '%s = %s',
-                    $this->getConstantVarName($varName),
+                    $this->getConstantVarName($stripPrefix ? str_replace($prefix, '', $varName) : $varName),
                     $_ENV[$varName]
                 );
                 $content .= chr(10);

--- a/tests/Unit/TypoScriptConstantsFilesTest.php
+++ b/tests/Unit/TypoScriptConstantsFilesTest.php
@@ -29,13 +29,20 @@ class TypoScriptConstantsFilesTest extends \PHPUnit_Framework_TestCase
         $mockedPackage->expects($this->any())
             ->method('getExtra')
             ->willReturn(['helhum/env-ts' => ['files' => [
-                'Config/TS/Evn.t3s' => ['FOO_']
+                'Config/TS/Evn.t3s' => [
+                    'FOO_',
+                    'BAR_' => true,
+                    'BAZ_' => false
+                ]
             ]]]);
         $root = vfsStream::setup('package-dir');
         $root->addChild(vfsStream::newDirectory('foo'));
         $config = PackageConfig::createFromPackage($mockedPackage, 'vfs://package-dir/foo');
         $_ENV['FOO_BAR__BAZ'] = 'foobarbaz';
         $_ENV['FOO_BLA__BAZ'] = 'fooblabaz';
+        $_ENV['BAR_ANOTHER_VAR'] = 'fooblabaz';
+        $_ENV['BAR__FOO__BAZ'] = 'fooblabaz';
+        $_ENV['BAZ_BAZ__BAR'] = 'fooblabaz';
 
         $constantsFile = new TypoScriptConstantsFiles($config);
         $constantsFile->write();
@@ -45,6 +52,14 @@ class TypoScriptConstantsFilesTest extends \PHPUnit_Framework_TestCase
             'environment.fooBar.baz = foobarbaz'
             . chr(10)
             . 'environment.fooBla.baz = fooblabaz'
+            . chr(10)
+            . chr(10)
+            . 'environment.anotherVar = fooblabaz'
+            . chr(10)
+            . 'environment.foo.baz = fooblabaz'
+            . chr(10)
+            . chr(10)
+            . 'environment.bazBaz.bar = fooblabaz'
             . chr(10),
             $fileContent
         );


### PR DESCRIPTION
I'd like to be able to remove the prefix from all my constant names.

Beside the other variables I use in my environment file this would clearly separate them from the typoscript variables.

E.g.:
There are some variables starting with `TYPO3_` which are used for general TYPO3 configuration.
Now I add `TYPOSCRIPT_CONFIG__DEBUG = 1`. At this point it is clear, that this variable will be used in typoscript (constants).

Also updated the unit test and it still succeeds.